### PR TITLE
Fix admin permission check

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,6 +96,10 @@ DISCORD_TOKEN=your_discord_bot_token_here
 - `/pred add_admin <user>` - Add a bot admin
 - `/pred remove_admin <user>` - Remove a bot admin
 - `/pred add_admin_role <role>` - Add an admin role
+- `/pred emergency_admin <secret>` - Grant temporary admin via secret key
+
+Admins are recognized either by one of the configured roles or by being
+explicitly listed in the server settings as `admin_users`.
 
 ## Timer Categories ⏰
 

--- a/commands.py
+++ b/commands.py
@@ -47,9 +47,14 @@ class GameCommands(app_commands.Group):
         """Check if user has permission to use admin commands."""
         if interaction.user.id == interaction.guild.owner_id:
             return True
-            
+
         config = self.bot.config_manager.get_server_config(interaction.guild.id)
         admin_roles = config.get('settings', {}).get('admin_roles', [])
+        admin_users = config.get('settings', {}).get('admin_users', [])
+
+        if interaction.user.id in admin_users:
+            return True
+
         return any(role.id in admin_roles for role in interaction.user.roles)
 
     def validate_config(self, config_data: dict) -> tuple[bool, str, dict]:


### PR DESCRIPTION
## Summary
- check both admin roles and user list when verifying permissions
- document emergency admin command and admin user list

## Testing
- `python -m py_compile commands.py config.py main.py services.py health_check.py`


------
https://chatgpt.com/codex/tasks/task_e_6855d0ebc544832a824e1992ff727a44