### PR TITLE
Add game mode support for Nitro

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -416,8 +416,11 @@ class GameCommands(app_commands.Group):
         ]
 
     @app_commands.command(name="start")
-    @app_commands.describe(time="Game time in M:SS format (defaults to 0:00)")
-    async def start(self, interaction: discord.Interaction, time: str = "00:00"):
+    @app_commands.describe(
+        time="Game time in M:SS format (defaults to 0:00)",
+        mode="Game mode (standard or nitro)"
+    )
+    async def start(self, interaction: discord.Interaction, time: str = "00:00", mode: str = "standard"):
         """Start the game timer."""
         try:
             if not interaction.user.voice:
@@ -427,8 +430,8 @@ class GameCommands(app_commands.Group):
             voice_channel = interaction.user.voice.channel
             await self.bot.voice_service.ensure_voice_client(voice_channel, force_new=True)
             
-            self.bot.timer.start(time)
-            await interaction.response.send_message(f"Game timer started at {time}")
+            self.bot.timer.start(time, mode)
+            await interaction.response.send_message(f"Game timer started at {time} in {mode} mode")
             
         except ValueError:
             await interaction.response.send_message("Invalid time format. Use M:SS (e.g., 0:05)")

--- a/config.py
+++ b/config.py
@@ -385,7 +385,8 @@ DEFAULT_CONFIG = {
             ],
             'category': TimerCategory.LATE_GAME.value
         }
-    }
+    },
+    'nitro_timers': {}
 }
 
 class ConfigManager:
@@ -558,10 +559,14 @@ class ConfigManager:
             return True
         return False
     
-    def get_server_timers(self, server_id: int, category: Optional[str] = None) -> Dict[str, Any]:
-        """Get all timers for a server, optionally filtered by category."""
+    def get_server_timers(self, server_id: int, category: Optional[str] = None,
+                          mode: str = 'standard') -> Dict[str, Any]:
+        """Get timers for a server and mode, optionally filtered by category."""
         config = self.get_server_config(server_id)
-        timers = config.get('timers', {})
+        if mode == 'nitro':
+            timers = config.get('nitro_timers', {})
+        else:
+            timers = config.get('timers', {})
         
         if category:
             return {


### PR DESCRIPTION
## Summary
- add empty `nitro_timers` section in config
- support selecting timer mode in bot command and loop
- store mode info in `GameTimer`
- use mode-aware `get_server_timers`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855d2c85dc8832ab61a242f6e431b58