### PR TITLE
Fix voice connection handling

### DIFF
--- a/services.py
+++ b/services.py
@@ -165,9 +165,11 @@ class VoiceService:
             
             # Connect to the new channel with timeout
             try:
-                voice_client = await asyncio.wait_for(
-                    channel.connect(),
-                    timeout=timeout
+                # Use discord.py's built-in timeout handling when connecting
+                # to allow the library to manage retries more gracefully.
+                voice_client = await channel.connect(
+                    timeout=timeout,
+                    reconnect=True
                 )
                 
                 # Set up timeouts


### PR DESCRIPTION
## Summary
- use built-in discord.py timeout for `channel.connect`
- let the library manage reconnect attempts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685786e61204832aabf24ac730709be3