### PR TITLE
Auto-add guild owner as bot admin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,6 +98,9 @@ DISCORD_TOKEN=your_discord_bot_token_here
 - `/pred add_admin_role <role>` - Add an admin role
 - `/pred emergency_admin <secret>` - Grant temporary admin via secret key
 
+When the bot joins a server or restarts, the guild owner is automatically added
+to the `admin_users` list so they can manage the bot immediately.
+
 Admins are recognized either by one of the configured roles or by being
 explicitly listed in the server settings as `admin_users`.
 

--- a/main.py
+++ b/main.py
@@ -138,6 +138,36 @@ class PredecessorBot(commands.Bot):
             logger.error(f"Error syncing commands in on_ready: {e}")
         logger.info('------')
 
+        # Ensure each guild owner is recorded as an admin user
+        for guild in self.guilds:
+            config = self.config_manager.get_server_config(guild.id)
+            admin_users = config.get('settings', {}).get('admin_users', [])
+            if guild.owner_id not in admin_users:
+                admin_users.append(guild.owner_id)
+                self.config_manager.update_server_setting(
+                    guild.id,
+                    'settings.admin_users',
+                    admin_users,
+                )
+                logger.info(
+                    f"Added guild owner {guild.owner_id} as admin for {guild.id}"
+                )
+
+    async def on_guild_join(self, guild: discord.Guild):
+        """Automatically add the guild owner to admin list when joining."""
+        config = self.config_manager.get_server_config(guild.id)
+        admin_users = config.get('settings', {}).get('admin_users', [])
+        if guild.owner_id not in admin_users:
+            admin_users.append(guild.owner_id)
+            self.config_manager.update_server_setting(
+                guild.id,
+                'settings.admin_users',
+                admin_users,
+            )
+            logger.info(
+                f"Guild join: added owner {guild.owner_id} as admin for {guild.id}"
+            )
+        
     # In main.py, update the check_timers method
     @tasks.loop(seconds=1.0)
     async def check_timers(self, mode: str = 'standard'):


### PR DESCRIPTION
## Summary
- automatically record guild owner as admin when the bot starts or joins a guild
- document this behavior in the README

## Testing
- `python -m py_compile main.py commands.py config.py services.py health_check.py`

------
https://chatgpt.com/codex/tasks/task_e_6857953e8f10832a9670de88a23ada8d